### PR TITLE
Expand-StackArchive - adding interrupt so command exits properly

### DIFF
--- a/functions/Expand-StackArchive.ps1
+++ b/functions/Expand-StackArchive.ps1
@@ -44,6 +44,7 @@ function Expand-StackArchive {
         }
     }
     process {
+        if (Test-PSFFunctionInterrupt) {return}
         if (Test-Path $FileName) {
             if ($List) {
                 szStackdb l $FileName

--- a/stackdb.psd1
+++ b/stackdb.psd1
@@ -12,7 +12,7 @@
     RootModule = 'stackdb.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.6.0'
+    ModuleVersion = '0.6.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
If 7z is not installed function was not exiting properly. Added call to test interrupt in process block to fix this.